### PR TITLE
v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ type Person =
       Age       : int option 
       StartDate : DateTime }
 
-let validatePersonDto (input : PersonDto) : ValidationResult<Person> = 
+let validatePersonDto (input : PersonDto) : Result<Person, ValidationErrors> = 
     // Shared validator for first & last name
     let nameValidator = 
         Validators.Default.String.betweenLen 3 64
@@ -130,7 +130,7 @@ let fooValidator =
 
 ## Validating Collections
 
-Applying validator(s) to a set of items will result in a `ValidationResult<'a> seq`
+Applying validator(s) to a set of items will result in a `Result<'a, ValidationErrors> seq`
 
 ```fsharp
 open Validus 
@@ -146,7 +146,7 @@ let result =
     emails
     |> List.map (emailValidator "Login email")
 
-// result is a ValidationResult<string> seq
+// result is a Result<string, ValidationErrors> seq
 
 // Outputs: [ "Login email", [ "Login email must be a valid email" ] ]
 ```
@@ -182,7 +182,7 @@ type Email =
 
         input
         |> Validator.create message rule field
-        |> ValidationResult.map (fun v -> { Email = v }) 
+        |> Result.map (fun v -> { Email = v }) 
 ```
 
 ### Example 2: E164 Formatted Phone Number
@@ -199,7 +199,7 @@ type E164 =
 
         input
         |> Validators.String.pattern e164Regex message field
-        |> ValidationResult.map (fun v -> { E164 = v })
+        |> Result.map (fun v -> { E164 = v })
 ```
 
 ## Built-in Validators
@@ -208,7 +208,7 @@ All of the built-in validators reside in the `Validators` module and follow a si
 
 ```fsharp
 // Produce a validation result based on a field name and value
-type Validator<'a> = string -> 'a -> ValidationResult<'a>
+type Validator<'a> = string -> 'a -> Result<'a, ValidationErrors>
 ```
 
 > Note: Validators pre-populated with English-language default error messages reside within the `Validators.Default` module.
@@ -225,14 +225,14 @@ open Validus
 let equalsFoo = 
   Validators.Default.String.equals "foo" "fieldName"
 
-equalsFoo "bar" // ValidationResult<string>
+equalsFoo "bar" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string equals
 // "foo" displaying a custom error message (string -> string).
 let equalsFooCustom = 
   Validators.String.equals "foo" (sprintf "%s must equal the word 'foo'") "fieldName"
 
-equalsFooCustom "bar" // ValidationResult<string>
+equalsFooCustom "bar" // Result<string, ValidationErrors>
 ```
 
 ## [`notEquals`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L103)
@@ -247,14 +247,14 @@ open Validus
 let notEqualsFoo = 
   Validators.Default.String.notEquals "foo" "fieldName"
 
-notEqualsFoo "bar" // ValidationResult<string>
+notEqualsFoo "bar" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is not 
 // equal to "foo" displaying a custom error message (string -> string)
 let notEqualsFooCustom = 
   Validators.String.notEquals "foo" (sprintf "%s must not equal the word 'foo'") "fieldName"
 
-notEqualsFooCustom "bar" // ValidationResult<string>
+notEqualsFooCustom "bar" // Result<string, ValidationErrors>
 ```
 
 ## [`between`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L110) (inclusive)
@@ -269,14 +269,14 @@ open Validus
 let between1and100 = 
   Validators.Default.Int.between 1 100 "fieldName"
 
-between1and100 12 // ValidationResult<int>
+between1and100 12 // Result<int, ValidationErrors>
 
 // Define a validator which checks if an int is between
 // 1 and 100 (inclusive) displaying a custom error message.
 let between1and100Custom = 
   Validators.Int.between 1 100 (sprintf "%s must be between 1 and 100") "fieldName"
 
-between1and100Custom 12 // ValidationResult<int>
+between1and100Custom 12 // Result<int, ValidationErrors>
 ```
 
 ## [`greaterThan`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L114)
@@ -291,14 +291,14 @@ open Validus
 let greaterThan100 = 
   Validators.Default.Int.greaterThan 100 "fieldName"
 
-greaterThan100 12 // ValidationResult<int>
+greaterThan100 12 // Result<int, ValidationErrors>
 
 // Define a validator which checks if an int is greater than
 // 100 displaying a custom error message.
 let greaterThan100Custom = 
   Validators.Int.greaterThan 100 (sprintf "%s must be greater than 100") "fieldName"
 
-greaterThan100Custom 12 // ValidationResult<int>
+greaterThan100Custom 12 // Result<int, ValidationErrors>
 ```
 
 ## [`lessThan`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L118)
@@ -313,14 +313,14 @@ open Validus
 let lessThan100 = 
   Validators.Default.Int.lessThan 100 "fieldName"
 
-lessThan100 12 // ValidationResult<int>
+lessThan100 12 // Result<int, ValidationErrors>
 
 // Define a validator which checks if an int is less than
 // 100 displaying a custom error message.
 let lessThan100Custom = 
   Validators.Int.lessThan 100 (sprintf "%s must be less than 100") "fieldName"
 
-lessThan100Custom 12 // ValidationResult<int>
+lessThan100Custom 12 // Result<int, ValidationErrors>
 ```
 
 ### String specific validators
@@ -337,14 +337,14 @@ open Validus
 let between1and100Chars = 
   Validators.Default.String.betweenLen 1 100 "fieldName"
 
-between1and100Chars "validus" // ValidationResult<string>
+between1and100Chars "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is between
 // 1 and 100 chars displaying a custom error message.
 let between1and100CharsCustom = 
   Validators.String.betweenLen 1 100 (sprintf "%s must be between 1 and 100 chars") "fieldName"
 
-between1and100CharsCustom "validus" // ValidationResult<string>
+between1and100CharsCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## [`equalsLen`](https://github.com/pimbrouwers/Validus/blob/e555cc01f41f2d717ecec32fcb46616dca7243e8/src/Validus/Validus.fs#L219)
@@ -359,14 +359,14 @@ open Validus
 let equals100Chars = 
   Validators.Default.String.equalsLen 100 "fieldName"
 
-equals100Chars "validus" // ValidationResult<string>
+equals100Chars "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is equals to
 // 100 chars displaying a custom error message.
 let equals100CharsCustom = 
   Validators.String.equalsLen 100 (sprintf "%s must be 100 chars") "fieldName"
 
-equals100CharsCustom "validus" // ValidationResult<string>
+equals100CharsCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## [`greaterThanLen`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L136)
@@ -381,14 +381,14 @@ open Validus
 let greaterThan100Chars = 
   Validators.Default.String.greaterThanLen 100 "fieldName"
 
-greaterThan100Chars "validus" // ValidationResult<string>
+greaterThan100Chars "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is greater than
 // 100 chars displaying a custom error message.
 let greaterThan100CharsCustom = 
   Validators.String.greaterThanLen 100 (sprintf "%s must be greater than 100 chars") "fieldName"
 
-greaterThan100CharsCustom "validus" // ValidationResult<string>
+greaterThan100CharsCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## [`lessThanLen`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L141)
@@ -403,14 +403,14 @@ open Validus
 let lessThan100Chars = 
   Validators.Default.String.lessThanLen 100 "fieldName"
 
-lessThan100Chars "validus" // ValidationResult<string>
+lessThan100Chars "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is less tha
 // 100 chars displaying a custom error message.
 let lessThan100CharsCustom = 
   Validators.String.lessThanLen 100 (sprintf "%s must be less than 100 chars") "fieldName"
 
-lessThan100CharsCustom "validus" // ValidationResult<string>
+lessThan100CharsCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## [`empty`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L131)
@@ -425,14 +425,14 @@ open Validus
 let stringIsEmpty = 
   Validators.Default.String.empty "fieldName"
 
-stringIsEmpty "validus" // ValidationResult<string>
+stringIsEmpty "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is empty
 // displaying a custom error message.
 let stringIsEmptyCustom = 
   Validators.String.empty (sprintf "%s must be empty") "fieldName"
 
-stringIsEmptyCustom "validus" // ValidationResult<string>
+stringIsEmptyCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## [`notEmpty`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L146)
@@ -447,14 +447,14 @@ open Validus
 let stringIsNotEmpty = 
   Validators.Default.String.notEmpty "fieldName"
 
-stringIsNotEmpty "validus" // ValidationResult<string>
+stringIsNotEmpty "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string is not empty
 // displaying a custom error message.
 let stringIsNotEmptyCustom = 
   Validators.String.notEmpty (sprintf "%s must not be empty") "fieldName"
 
-stringIsNotEmptyCustom "validus" // ValidationResult<string>
+stringIsNotEmptyCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## [`pattern`](https://github.com/pimbrouwers/Validus/blob/cb168960b788ea50914c661fcbba3cf096ec4f3a/src/Validus/Validus.fs#L151) (Regular Expressions)
@@ -469,14 +469,14 @@ open Validus
 let stringIsChars = 
   Validators.Default.String.pattern "[a-z]" "fieldName"
 
-stringIsChars "validus" // ValidationResult<string>
+stringIsChars "validus" // Result<string, ValidationErrors>
 
 // Define a validator which checks if a string matches the 
 // provided regex displaying a custom error message.
 let stringIsCharsCustom = 
   Validators.String.pattern "[a-z]" (sprintf "%s must follow the pattern [a-z]") "fieldName"
 
-stringIsCharsCustom "validus" // ValidationResult<string>
+stringIsCharsCustom "validus" // Result<string, ValidationErrors>
 ```
 
 ## Find a bug?

--- a/src/Validus.Tests/ComparisonValidatorTests.fs
+++ b/src/Validus.Tests/ComparisonValidatorTests.fs
@@ -11,7 +11,7 @@ let ``(TestValidator.between min max) should produce Success`` (NonZeroInt min) 
     let max = min + 100000
     let v = min + 50000
     match TestValidator.between min max "Test" v with
-    | Success _ -> true
+    | Ok _ -> true
     | _ -> false
 
 [<Property>]
@@ -19,21 +19,21 @@ let ``(TestValidator.between min max) should produce Failure`` (NonZeroInt min) 
     let max = min + 100000
     let v = min + 150000
     match TestValidator.between min max "Test" v with
-    | Success _ -> false
+    | Ok _ -> false
     | _ -> true
 
 [<Property>]
 let ``(TestValidator.graterThan min) should produce Success`` (NonZeroInt min) =           
     let v = min + 50000
     match TestValidator.greaterThan min "Test" v with
-    | Success _ -> true
+    | Ok _ -> true
     | _ -> false   
     
 [<Property>]
 let ``(TestValidator.graterThan min) should produce Failure`` (NonZeroInt min) =           
     let v = min - 50000
     match TestValidator.greaterThan min "Test" v with
-    | Success _ -> false
+    | Ok _ -> false
     | _ -> true
 
 [<Property>]
@@ -41,7 +41,7 @@ let ``(TestValidator.lessThan max) should produce Success`` (NonZeroInt min) =
     let max = min + 100000
     let v = min + 50000
     match TestValidator.lessThan max "Test" v with
-    | Success _ -> true
+    | Ok _ -> true
     | _ -> false
 
 [<Property>]
@@ -49,5 +49,5 @@ let ``(TestValidator.lessThan max) should produce Failure`` (NonZeroInt min) =
     let max = min + 100000
     let v = min + 150000
     match TestValidator.lessThan max "Test" v with
-    | Success _ -> false
+    | Ok _ -> false
     | _ -> true

--- a/src/Validus.Tests/EqualityValidatorTests.fs
+++ b/src/Validus.Tests/EqualityValidatorTests.fs
@@ -9,24 +9,24 @@ let private TestValidator = Validators.Default.DefaultEqualityValidator(Validato
 [<Property>]
 let ``(TestValidator.equals n) should produce Success`` (NonZeroInt n) =           
     match TestValidator.equals n "Test" n with
-    | Success _ -> true
+    | Ok _ -> true
     | _ -> false
 
 [<Property>]
 let ``(TestValidator.equals n) should produce Failure`` (NonZeroInt n) =           
     match TestValidator.equals n "Test" 0 with
-    | Failure _ -> true
+    | Error _ -> true
     | _ -> false
 
 [<Property>]
 let ``(TestValidator.notEquals n) should produce Success`` (NonZeroInt n) =           
     match TestValidator.notEquals n "Test" 0 with
-    | Success _ -> true
+    | Ok _ -> true
     | _ -> false
 
 [<Property>]
 let ``(TestValidator.notEquals n) should produce Failure`` (NonZeroInt n) =           
     match TestValidator.notEquals n "Test" n with
-    | Failure _ -> true
+    | Error _ -> true
     | _ -> false
     

--- a/src/Validus.Tests/GuidValidatorTests.fs
+++ b/src/Validus.Tests/GuidValidatorTests.fs
@@ -11,23 +11,23 @@ let private testGuid = Guid.NewGuid ()
 [<Property>]
 let ``(TestValidator.empty) should produce Success`` () =           
     match TestValidator.empty "Test" Guid.Empty with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.empty) should produce Failure`` () =           
     match TestValidator.empty "Test" testGuid with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true
 
 [<Property>]
 let ``(TestValidator.notEmpty) should produce Success`` () =           
     match TestValidator.notEmpty "Test" testGuid with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.notEmpty) should produce Failure`` () =           
     match TestValidator.notEmpty "Test" Guid.Empty with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true

--- a/src/Validus.Tests/StringValidatorTests.fs
+++ b/src/Validus.Tests/StringValidatorTests.fs
@@ -10,77 +10,77 @@ let private testString = "validus"
 [<Property>]
 let ``(TestValidator.betweenLen min max) should produce Success`` () =               
     match TestValidator.betweenLen 0 100 "Test" testString with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.betweenLen min max) should produce Failure`` () =               
     match TestValidator.betweenLen 100 1000 "Test" testString with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true
 
 [<Property>]
 let ``(TestValidator.empty) should produce Success`` () =           
     match TestValidator.empty "Test" "" with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.empty) should produce Failure`` () =           
     match TestValidator.empty "Test" testString with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true
 
 [<Property>]
 let ``(TestValidator.equalsLen len) should produce Success`` () =               
     match TestValidator.equalsLen 7 "Test" testString with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.greaterThanLen min) should produce Success`` () =               
     match TestValidator.greaterThanLen 0 "Test" testString with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.greaterThanLen min) should produce Failure`` () =           
     match TestValidator.greaterThanLen 100 "Test" testString with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true
 
 [<Property>]
 let ``(TestValidator.lessThanLen min) should produce Success`` () =               
     match TestValidator.lessThanLen 100 "Test" testString with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.lessThanLen min) should produce Failure`` () =           
     match TestValidator.lessThanLen 0 "Test" testString with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true
 
 [<Property>]
 let ``(TestValidator.notEmpty) should produce Success`` () =           
     match TestValidator.notEmpty "Test" testString with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.notEmpty) should produce Failure`` () =           
     match TestValidator.notEmpty "Test" "" with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true
 
 [<Property>]
 let ``(TestValidator.pattern) [a-z] should produce Success`` () =           
     match TestValidator.pattern "[a-z]" "Test" testString with
-    | Success _ -> true
-    | Failure _ -> false
+    | Ok _ -> true
+    | Error _ -> false
 
 [<Property>]
 let ``(TestValidator.pattern) [a-z] should produce Failure`` () =           
     match TestValidator.pattern "[a-z]" "Test" "123456789" with
-    | Success _ -> false
-    | Failure _ -> true
+    | Ok _ -> false
+    | Error _ -> true

--- a/src/Validus.Tests/ValidationErrorsTests.fs
+++ b/src/Validus.Tests/ValidationErrorsTests.fs
@@ -5,10 +5,6 @@ open Validus
 open FsUnit.Xunit
 
 [<Fact>]
-let ``ValidationErrors.empty produces empty Map<string, string list>`` () =
-    ValidationErrors.empty |> ValidationErrors.toMap |> should equal Map.empty<string, string list>
-
-[<Fact>]
 let ``ValidationErrors.create produce Map<string, string list> from field and errors`` () =
     let expected = [ "fakeField1", [ "fake error message 1" ] ] |> Map.ofList
     let error = ValidationErrors.create "fakeField1" [ "fake error message 1" ]

--- a/src/Validus.Tests/ValidationResultTests.fs
+++ b/src/Validus.Tests/ValidationResultTests.fs
@@ -18,23 +18,10 @@ type FakeValidationRecordWithOption =
         { Name = name; Age = age }
 
 [<Fact>]
-let ``ValidationResult.create produces Ok result`` () =    
-    ValidationResult.create true () ValidationErrors.empty    
-    |> ValidationResult.map (fun result -> result |> should equal ())
-
-[<Fact>]
-let ``ValidationResult.create produces Error result`` () =    
-    let expected = ValidationErrors.create "fakeField" [ "fake error message" ]
-    
-    match ValidationResult.create false () expected with
-    | Success _ -> ()
-    | Failure e -> e |> should equal expected
-
-[<Fact>]
 let ``Can bind ValidationResults`` () =
     let expected : FakeValidationRecord = { Name = "John"; Age = 1 }    
 
-    let result : ValidationResult<string> =         
+    let result : Result<string, ValidationErrors> =         
         let validator = 
             Validators.Default.String.greaterThanLen 2
             <+> Validators.Default.String.lessThanLen 100            
@@ -48,8 +35,8 @@ let ``Can bind ValidationResults`` () =
         let message = fun field -> sprintf "%s must equal %s" field expected.Name
         let validator name =             
             match Validator.create message rule "Name" name with 
-            | Success x -> Success {|Name = x |}
-            | Failure e -> Failure e
+            | Ok x -> Ok {|Name = x |}
+            | Error e -> Error e
 
         validate {
             let! result = result
@@ -57,13 +44,12 @@ let ``Can bind ValidationResults`` () =
         }
     
     result3    
-    |> ValidationResult.toResult
     |> Result.bind (fun r -> Ok(r |> should equal {|Name = expected.Name|}))
     
 [<Fact>]
 let ``Validation of record succeeds using computation expression`` () =        
     let expected : FakeValidationRecord = { Name = "John"; Age = 1 }    
-    let result : ValidationResult<FakeValidationRecord> = 
+    let result : Result<FakeValidationRecord, ValidationErrors> = 
         let nameValidator =             
             Validators.Default.String.greaterThanLen 2
             <+> Validators.Default.String.lessThanLen 100
@@ -76,13 +62,12 @@ let ``Validation of record succeeds using computation expression`` () =
         }
     
     result 
-    |> ValidationResult.toResult
     |> Result.bind (fun r -> Ok(r |> should equal expected))
 
 [<Fact>]
 let ``Validation of record with option succeeds`` () =        
     let expected : FakeValidationRecordWithOption = { Name = "John"; Age = None }
-    let result : ValidationResult<FakeValidationRecordWithOption> = 
+    let result : Result<FakeValidationRecordWithOption, ValidationErrors> = 
         let nameValidator = 
             Validators.Default.String.greaterThanLen 2 "Name" expected.Name
 
@@ -97,14 +82,13 @@ let ``Validation of record with option succeeds`` () =
         <*> ageValidator
     
     result 
-    |> ValidationResult.toResult
     |> Result.bind (fun r -> Ok (r |> should equal expected))
 
 [<Fact>]
 let ``Validation of record fails`` () =           
     let name = "Jo"
     let age = 3
-    let result : ValidationResult<FakeValidationRecord> =         
+    let result : Result<FakeValidationRecord, ValidationErrors> =         
         let nameValidator =             
             Validators.Default.String.greaterThanLen 2
             <+> Validators.Default.String.lessThanLen 100
@@ -114,7 +98,6 @@ let ``Validation of record fails`` () =
         <*> Validators.Int.greaterThan 3 (sprintf "%s must be greater than 3") "Age" age
     
     result 
-    |> ValidationResult.toResult
     |> Result.mapError (fun r -> 
         let rMap = ValidationErrors.toMap r
         (rMap.ContainsKey "Name", rMap.ContainsKey "Age") |> should equal (true, true)
@@ -124,7 +107,7 @@ let ``Validation of record fails`` () =
 let ``Validation of record fails with computation expression`` () =           
     let name = "Jo"
     let age = 3
-    let result : ValidationResult<FakeValidationRecord> =         
+    let result : Result<FakeValidationRecord, ValidationErrors> =         
         let nameValidator =             
             Validators.Default.String.greaterThanLen 2
             <+> Validators.Default.String.lessThanLen 100
@@ -136,57 +119,7 @@ let ``Validation of record fails with computation expression`` () =
         }
     
     result 
-    |> ValidationResult.toResult
     |> Result.mapError (fun r -> 
         let rMap = ValidationErrors.toMap r
         (rMap.ContainsKey "Name", rMap.ContainsKey "Age") |> should equal (true, true)
         rMap.["Age"] |> should equal ["Age must be greater than 3"])
-
-[<Fact>]
-let ``Validation of record fails and can be flattened`` () =           
-    let name = "Jo"    
-    let result : ValidationResult<string> =         
-        let nameValidator =             
-            Validators.Default.String.greaterThanLen 2
-            <+> Validators.Default.String.lessThanLen 100
-        
-        validate {
-            let! name = nameValidator "Name" name
-            return name
-        }
-    
-    let flattened = ValidationResult.flatten result     
-
-    flattened 
-    |> should be instanceOfType<Result<string, string list>>
-
-    flattened 
-    |> Result.mapError(fun r -> r |> should haveLength 1)
-
-[<Fact>]
-let ``Validation of multiple record fails and can be sequenced`` () =    
-    let names = [ "Jo"; "Jim"; "Lo"; "Bob" ]
-    
-    let nameValidator =             
-        Validators.Default.String.greaterThanLen 2
-        <+> Validators.Default.String.lessThanLen 100
-
-    let validator name =           
-        validate {
-            let! name = nameValidator "Name" name
-            return name
-        }
-
-    let result = 
-        names 
-        |> List.map validator
-
-    let sequenced =
-        result
-        |> ValidationResult.sequence
-
-    result 
-    |> should be instanceOfType<ValidationResult<string> seq>
-
-    sequenced
-    |> should be instanceOfType<ValidationResult<string seq>>

--- a/src/Validus/Validus.fs
+++ b/src/Validus/Validus.fs
@@ -1,4 +1,4 @@
-﻿module Validus
+module Validus
 
 open System
 
@@ -8,23 +8,20 @@ open System
 
 /// A mapping of fields and errors
 type ValidationErrors = private { ValidationErrors : Map<string, string list> } with
-    member x.Value = x.ValidationErrors
+    member internal x.Value = x.ValidationErrors
 
-let inline private validationErrors x = { ValidationErrors = x }    
+let inline private validationErrors x = { ValidationErrors = x }
 
 /// Functions for ValidationErrors type
 module ValidationErrors =
-    /// Empty ValidationErrors, alias for Map.empty<string, string list>
-    let empty : ValidationErrors = Map.empty<string, string list> |> validationErrors
-
     /// Create a new ValidationErrors instance from a field  and errors list
-    let create (field : string) (errors : string list) : ValidationErrors =   
+    let create (field : string) (errors : string list) : ValidationErrors =
         [ field, errors ] |> Map.ofList |> validationErrors
 
     /// Combine two ValidationErrors instances
-    let merge (e1 : ValidationErrors) (e2 : ValidationErrors) : ValidationErrors = 
-        Map.fold 
-            (fun acc k v -> 
+    let merge (e1 : ValidationErrors) (e2 : ValidationErrors) : ValidationErrors =
+        Map.fold
+            (fun acc k v ->
                 match Map.tryFind k acc with
                 | Some v' -> Map.add k (v' @ v) acc
                 | None    -> Map.add k v acc)
@@ -33,92 +30,45 @@ module ValidationErrors =
         |> validationErrors
 
     /// Unwrap ValidationErrors into a standard Map<string, string list>
-    let toMap (e : ValidationErrors) : Map<string, string list> =        
+    let toMap (e : ValidationErrors) : Map<string, string list> =
         e.Value
 
     /// Unwrap ValidationErrors and collection individual errors into
     /// string list, excluding keys
     let toList (e : ValidationErrors) : string list =
-        e 
+        e
         |> toMap
         |> Seq.collect (fun kvp -> kvp.Value)
         |> List.ofSeq
-
 
 // ------------------------------------------------
 // Validation Results
 // ------------------------------------------------
 
-/// The ValidationResult type represents a choice between success and failure
-type ValidationResult<'a> = Success of 'a | Failure of ValidationErrors
-
-/// A validation message for a field
-type ValidationMessage = string -> string
-
-/// Given a value, return true/false to indicate validity
-type ValidationRule<'a> = 'a -> bool
-
-/// Given a field name and value, 'a, produces a ValidationResult<'a>
-type Validator<'a> = string -> 'a -> ValidationResult<'a>
-
 /// Functions for ValidationResult type
-module ValidationResult = 
-    /// Convert regular value 'a into ValidationResult<'a>
-    let retn (v : 'a) = Success v
-
-    /// Bind content of ValidationResult<'a> to 'a -> ValidationResult<'b>
-    let bind (resultFn : 'a -> ValidationResult<'b>) (result : ValidationResult<'a>)  : ValidationResult<'b> =
-        match result with 
-        | Success x -> resultFn x
-        | Failure e -> Failure e
-
+module ValidationResult =
     /// Unpack ValidationResult and feed into validation function
-    let apply (resultFn : ValidationResult<'a -> 'b>) (result : ValidationResult<'a>) : ValidationResult<'b> =
+    let apply
+        (resultFn : Result<'a -> 'b, ValidationErrors>)
+        (result : Result<'a, ValidationErrors>)
+        : Result<'b, ValidationErrors> =
         match resultFn, result with
-        | Success fn, Success x  -> fn x |> Success
-        | Failure e, Success _   -> Failure e
-        | Success _, Failure e   -> Failure e
-        | Failure e1, Failure e2 -> Failure (ValidationErrors.merge e1 e2)  
+        | Ok fn, Ok x  -> fn x |> Ok
+        | Error e, Ok _   -> Error e
+        | Ok _, Error e   -> Error e
+        | Error e1, Error e2 -> Error (ValidationErrors.merge e1 e2)
 
-    /// Create a ValidationResult<'a> based on condition, yield
-    /// error message if condition evaluates false
-    let create (condition : bool) (value : 'a) (error : ValidationErrors) : ValidationResult<'a> =
-        if condition then Success value
-        else error |> Failure
-
-    /// Unpack ValidationResult, evaluate function if Success or return if Failure
-    let map (fn : 'a -> 'b) (result : ValidationResult<'a>) : ValidationResult<'b> =
-        apply (retn fn) result
-
-    /// Transform ValidationResult<'a> to Result<'a, ValidationErrors>
-    let toResult (result : ValidationResult<'a>) : Result<'a, ValidationErrors> =
-        match result with 
-        | Success r -> Ok r
-        | Failure e -> Error e
-
-    /// Transform & flatten ValidationResult<'a> to Result<'a, string list>
-    let flatten (x : ValidationResult<'a>) : Result<'a, string list> = 
-        x 
-        |> toResult
-        |> Result.mapError ValidationErrors.toList
-
-    /// Convert ValidationResult<'a> seq into ValidationResult<'a seq>
-    let sequence (items : ValidationResult<'a> seq) : ValidationResult<'a seq> =
-        items
-        |> Seq.fold (fun acc i ->
-            match (i, acc) with
-            | Success i, Success acc -> Success (Seq.append acc (seq { i }))
-            | _, Failure e
-            | Failure e, _ -> Failure e) (Success Seq.empty)    
-
-    /// Create a tuple form ValidationResult, if two ValidationResult objects are 
-    /// in Success state, otherwise return failure
-    let zip (r1 : ValidationResult<'a>) (r2 : ValidationResult<'b>) : ValidationResult<'a * 'b> =
+    /// Create a tuple form ValidationResult, if two ValidationResult objects
+    /// are in Ok state, otherwise return failure
+    let zip
+        (r1 : Result<'a, ValidationErrors>)
+        (r2 : Result<'b, ValidationErrors>)
+        : Result<'a * 'b, ValidationErrors> =
         match r1, r2 with
-        | Success x1res, Success x2res -> Success (x1res, x2res)
-        | Failure e1, Failure e2       -> Failure (ValidationErrors.merge e1 e2)
-        | Failure e, _                 -> Failure e
-        | _, Failure e                 -> Failure e
+        | Ok x1res, Ok x2res -> Ok (x1res, x2res)
+        | Error e1, Error e2 -> Error (ValidationErrors.merge e1 e2)
+        | Error e, _         -> Error e
+        | _, Error e         -> Error e
 
 
 // ------------------------------------------------
@@ -127,129 +77,182 @@ module ValidationResult =
 
 /// Validation rules
 module ValidationRule =
-    let equality<'a when 'a : equality> (equalTo : 'a) : ValidationRule<'a> = 
+    let equality<'a when 'a : equality> (equalTo : 'a) : 'a -> bool =
         fun v -> v = equalTo
-    
-    let inequality<'a when 'a : equality> (notEqualTo : 'a) : ValidationRule<'a>= 
+
+    let inequality<'a when 'a : equality> (notEqualTo : 'a) : 'a -> bool=
         fun v -> not(v = notEqualTo)
 
-    let between<'a when 'a : comparison> (min : 'a) (max : 'a) : ValidationRule<'a> = 
-        fun v -> v >= min && v <= max            
+    let between<'a when 'a : comparison> (min : 'a) (max : 'a) : 'a -> bool =
+        fun v -> v >= min && v <= max
 
-    let greaterThan<'a when 'a : comparison> (min : 'a) : ValidationRule<'a> = 
+    let greaterThan<'a when 'a : comparison> (min : 'a) : 'a -> bool =
         fun v -> v > min
 
-    let lessThan<'a when 'a : comparison> (max : 'a) : ValidationRule<'a> = 
+    let lessThan<'a when 'a : comparison> (max : 'a) : 'a -> bool =
         fun v -> v < max
 
-    let betweenLen (min : int) (max : int) : ValidationRule<string> =
+    let betweenLen (min : int) (max : int) : string -> bool =
         fun str -> str.Length |> between min max
 
-    let equalsLen (len : int) : ValidationRule<string> =
+    let equalsLen (len : int) : string -> bool =
         fun str -> str.Length |> equality len
 
-    let greaterThanLen (min : int) : ValidationRule<string> =
+    let greaterThanLen (min : int) : string -> bool =
         fun str -> str.Length |> greaterThan min
 
-    let lessThanLen (max : int) : ValidationRule<string> =
+    let lessThanLen (max : int) : string -> bool =
         fun str -> str.Length |> lessThan max
 
-    let pattern (pattern : string) : ValidationRule<string> =
+    let pattern (pattern : string) : string -> bool =
         fun v -> Text.RegularExpressions.Regex.IsMatch(v, pattern)
 
 /// Functions for Validator type
-module Validator =     
+module Validator =
     /// Combine two Validators
-    let compose (v1 : Validator<'a>) (v2 : Validator<'a>) : Validator<'a> =
-        fun (field : string) (value : 'a) ->            
+    let compose
+        (v1 : string -> 'a -> Result<'a, ValidationErrors>)
+        (v2 : string -> 'a -> Result<'a, ValidationErrors>)
+        : string -> 'a -> Result<'a, ValidationErrors> =
+        fun (field : string) (value : 'a) ->
             match v1 field value, v2 field value with
-            | Success a, Success _   -> Success a
-            | Failure e, Success _   -> Failure e
-            | Success _, Failure e   -> Failure e
-            | Failure e1, Failure e2 -> Failure (ValidationErrors.merge e1 e2)                           
+            | Ok a, Ok _   -> Ok a
+            | Error e, Ok _   -> Error e
+            | Ok _, Error e   -> Error e
+            | Error e1, Error e2 -> Error (ValidationErrors.merge e1 e2)
 
     /// Create a new Validator
-    let create (message : ValidationMessage) (rule : ValidationRule<'a>) : Validator<'a> = 
+    let create
+        (message : string -> string)
+        (rule : 'a -> bool)
+        : string -> 'a -> Result<'a, ValidationErrors> =
         fun (field : string) (value : 'a) ->
             let error = ValidationErrors.create field [ message field ]
-            ValidationResult.create (rule value) value error
+            if rule value then Ok value
+            else error |> Error
 
 /// Validation functions for prim itive types
-module Validators = 
-    /// Execute validator if 'a is Some, otherwise return Success 'a
-    let optional (validator : Validator<'a>) (field : string) (value : 'a option): ValidationResult<'a option> =  
+module Validators =
+    /// Execute validator if 'a is Some, otherwise return Ok 'a
+    let optional
+        (validator : string -> 'a -> Result<'a, ValidationErrors>)
+        (field : string) (value : 'a option)
+        : Result<'a option, ValidationErrors> =
         match value with
-        | Some v -> validator field v |> ValidationResult.map (fun v -> Some v)
-        | None   -> Success value
+        | Some v -> validator field v |> Result.map (fun v -> Some v)
+        | None   -> Ok value
 
-    /// Execute validator if 'a is Some, otherwise return Failure 
-    let required (validator : Validator<'a>) (message : ValidationMessage) (field : string) (value : 'a option) : ValidationResult<'a> =          
+    /// Execute validator if 'a is Some, otherwise return Failure
+    let required
+        (validator : string -> 'a -> Result<'a, ValidationErrors>)
+        (message : string -> string)
+        (field : string)
+        (value : 'a option)
+        : Result<'a, ValidationErrors> =
         match value with
         | Some v -> validator field v
-        | None   -> Failure (ValidationErrors.create field [ message field ])           
-         
+        | None   -> Error (ValidationErrors.create field [ message field ])
+
     type EqualityValidator<'a when 'a : equality>() =
         /// Value is equal to provided value
-        member _.equals (equalTo : 'a) (message : ValidationMessage) : Validator<'a> =            
+        member _.equals
+            (equalTo : 'a)
+            (message : string -> string)
+            : string -> 'a -> Result<'a, ValidationErrors> =
             let rule = ValidationRule.equality equalTo
             Validator.create message rule
 
         /// Value is not equal to provided value
-        member _.notEquals (notEqualTo : 'a) (message : ValidationMessage) : Validator<'a> =                        
+        member _.notEquals
+            (notEqualTo : 'a)
+            (message : string -> string)
+            : string -> 'a -> Result<'a, ValidationErrors> =
             let rule = ValidationRule.inequality notEqualTo
-            Validator.create message rule    
-                
-    type ComparisonValidator<'a when 'a : comparison>() = 
+            Validator.create message rule
+
+    type ComparisonValidator<'a when 'a : comparison>() =
         inherit EqualityValidator<'a>()
 
         /// Value is inclusively between provided min and max
-        member _.between (min : 'a) (max : 'a) (message : ValidationMessage) : Validator<'a> =                        
+        member _.between
+            (min : 'a)
+            (max : 'a)
+            (message : string -> string)
+            : string -> 'a -> Result<'a, ValidationErrors> =
             let rule = ValidationRule.between min max
             Validator.create message rule
-        
+
         /// Value is greater than provided min
-        member _.greaterThan (min : 'a) (message : ValidationMessage) : Validator<'a> =                        
+        member _.greaterThan
+            (min : 'a)
+            (message : string -> string)
+            : string -> 'a -> Result<'a, ValidationErrors> =
             let rule = ValidationRule.greaterThan min
             Validator.create message rule
-        
+
         /// Value is less than provided max
-        member _.lessThan (max : 'a) (message : ValidationMessage) : Validator<'a> =                                    
+        member _.lessThan
+            (max : 'a)
+            (message : string -> string)
+            : string -> 'a -> Result<'a, ValidationErrors> =
             let rule = ValidationRule.lessThan max
             Validator.create message rule
-    
+
     type StringValidator() =
-        inherit EqualityValidator<string>() 
+        inherit EqualityValidator<string>()
 
         /// Validate string is between length (inclusive)
-        member _.betweenLen (min : int) (max : int) (message : ValidationMessage) : Validator<string> =            
+        member _.betweenLen
+            (min : int)
+            (max : int)
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
             let rule = ValidationRule.betweenLen min max
             Validator.create message rule
 
         /// Validate string is null or ""
-        member _.empty (message : ValidationMessage) : Validator<string> =            
+        member _.empty
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
             Validator.create message String.IsNullOrWhiteSpace
 
         /// Validate string length is equal to provided value
-        member _.equalsLen (len : int) (message : ValidationMessage) : Validator<string> =            
+        member _.equalsLen
+            (len : int)
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
             let rule = ValidationRule.equalsLen len
             Validator.create message rule
 
         /// Validate string length is greater than provided value
-        member _.greaterThanLen (min : int) (message : ValidationMessage) : Validator<string> =            
+        member _.greaterThanLen
+            (min : int)
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
             let rule = ValidationRule.greaterThanLen min
             Validator.create message rule
 
         /// Validate string length is less than provided value
-        member _.lessThanLen (max : int) (message : ValidationMessage) : Validator<string> =            
+        member _.lessThanLen
+            (max : int)
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
             let rule = ValidationRule.lessThanLen max
             Validator.create message rule
 
         /// Validate string is not null or ""
-        member _.notEmpty (message : ValidationMessage) : Validator<string> =            
-            Validator.create message (fun str -> not(String.IsNullOrWhiteSpace (str)))
+        member _.notEmpty
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
+            Validator.create
+                message
+                (fun str -> not(String.IsNullOrWhiteSpace (str)))
 
         /// Validate string matches regular expression
-        member _.pattern (pattern : string) (message : ValidationMessage) : Validator<string> =            
+        member _.pattern
+            (pattern : string)
+            (message : string -> string)
+            : string -> string -> Result<string, ValidationErrors> =
             let rule = ValidationRule.pattern pattern
             Validator.create message rule
 
@@ -257,17 +260,21 @@ module Validators =
         inherit EqualityValidator<Guid> ()
 
         /// Validate string is null or ""
-        member _.empty (message : ValidationMessage) : Validator<Guid> =            
+        member _.empty
+            (message : string -> string)
+            : string -> Guid -> Result<Guid, ValidationErrors> =
             Validator.create message (fun guid -> Guid.Empty = guid)
 
         /// Validate string is not null or ""
-        member _.notEmpty (message : ValidationMessage) : Validator<Guid> =            
+        member _.notEmpty
+            (message : string -> string)
+            : string -> Guid -> Result<Guid, ValidationErrors> =
             Validator.create message (fun guid -> Guid.Empty <> guid)
 
 
     /// DateTime validators
     let DateTime = ComparisonValidator<DateTime>()
-    
+
     /// DateTimeOffset validators
     let DateTimeOffset = ComparisonValidator<DateTimeOffset>()
 
@@ -281,7 +288,7 @@ module Validators =
     let Guid = GuidValidator()
 
     /// int32 validators
-    let Int = ComparisonValidator<int>()    
+    let Int = ComparisonValidator<int>()
 
     /// int16 validators
     let Int16 = ComparisonValidator<int16>()
@@ -295,87 +302,140 @@ module Validators =
     /// System.TimeSpan validators
     let TimeSpan = ComparisonValidator<TimeSpan>()
 
-    module Default = 
-        type DefaultEqualityValidator<'a when 'a : equality>(x : EqualityValidator<'a>) =        
+    module Default =
+        type DefaultEqualityValidator<'a when 'a
+            : equality>(x : EqualityValidator<'a>) =
             /// Value is equal to provided value with the default error message
-            member _.equals (equalTo: 'a) : Validator<'a> = x.equals equalTo (fun field -> sprintf "%s must be equal to %A" field equalTo)
-        
-            /// Value is not equal to provided value with the default error message
-            member _.notEquals (notEqualTo : 'a) = x.notEquals notEqualTo (fun field -> sprintf "%s must not equal %A" field notEqualTo)
-        
-        type DefaultComparisonValidator<'a when 'a : comparison>(x : ComparisonValidator<'a>) = 
-            inherit DefaultEqualityValidator<'a>(x)
-    
-            /// Value is inclusively between provided min and max with the default error message
-            member _.between (min : 'a) (max : 'a) = x.between min max (fun field -> sprintf "%s must be between %A and %A" field min max)
-                    
-            /// Value is greater than provided min with the default error message
-            member _.greaterThan (min : 'a) = x.greaterThan min (fun field -> sprintf "%s must be greater than or equal to %A" field min)
-    
-            /// Value is less than provided max with the default error message
-            member _.lessThan (max : 'a) = x.lessThan max (fun field -> sprintf "%s must be less than or equal to %A" field max)
-    
-        type DefaultStringValidator(this : StringValidator) =
-            inherit DefaultEqualityValidator<string>(this) 
+            member _.equals (equalTo: 'a) =
+                let msg field = sprintf "%s must be equal to %A" field equalTo                
+                x.equals equalTo msg
 
-            /// Validate string is between length (inclusive) with the default error message
-            member _.betweenLen (min : int) (max : int) = this.betweenLen min max (fun field -> sprintf "%s must be between %i and %i characters" field min max)
+            /// Value is not equal to provided value with the default 
+            /// error message
+            member _.notEquals (notEqualTo : 'a) = 
+                let msg field = sprintf "%s must not equal %A" field notEqualTo
+                x.notEquals notEqualTo msg
+
+        type DefaultComparisonValidator<'a when 'a 
+            : comparison>(x : ComparisonValidator<'a>) =
+            inherit DefaultEqualityValidator<'a>(x)
+
+            /// Value is inclusively between provided min and max with the 
+            /// default error message
+            member _.between (min : 'a) (max : 'a) = 
+                let msg field = 
+                    sprintf "%s must be between %A and %A" field min max
+                x.between min max msg
+
+            /// Value is greater than provided min with the default error 
+            /// message
+            member _.greaterThan (min : 'a) = 
+                let msg field = 
+                    sprintf "%s must be greater than or equal to %A" field min
+                x.greaterThan min msg
+
+            /// Value is less than provided max with the default error message
+            member _.lessThan (max : 'a) = 
+                let msg field = 
+                    sprintf "%s must be less than or equal to %A" field max
+                x.lessThan max msg
+
+        type DefaultStringValidator(x : StringValidator) =
+            inherit DefaultEqualityValidator<string>(x)
+
+            /// Validate string is between length (inclusive) with the default 
+            /// error message
+            member _.betweenLen (min : int) (max : int) = 
+                let msg field =
+                    sprintf 
+                        "%s must be between %i and %i characters" 
+                        field min max
+                x.betweenLen min max msg
 
             /// Validate string is null or "" with the default error message
-            member _.empty = this.empty (fun field -> sprintf "%s must be empty" field)
+            member _.empty = 
+                let msg field = sprintf "%s must be empty" field
+                x.empty msg
 
-            /// Validate string length is greater than provided value with the default error message
-            member _.equalsLen (len : int) = this.equalsLen len (fun field -> sprintf "%s must be %i characters" field len)
+            /// Validate string length is greater than provided value with the 
+            /// default error message
+            member _.equalsLen (len : int) = 
+                let msg field = sprintf "%s must be %i characters" field len
+                x.equalsLen len msg
 
-            /// Validate string length is greater than provided value with the default error message
-            member _.greaterThanLen (min : int) = this.greaterThanLen min (fun field -> sprintf "%s must not execeed %i characters" field min)
+            /// Validate string length is greater than provided value with the 
+            /// default error message
+            member _.greaterThanLen (min : int) = 
+                let msg field = 
+                    sprintf "%s must not execeed %i characters" field min
+                x.greaterThanLen min msg
 
-            /// Validate string length is less than provided value with the default error message
-            member _.lessThanLen (max : int) = this.lessThanLen max (fun field -> sprintf "%s must be at least %i characters" field max)
+            /// Validate string length is less than provided value with the 
+            /// default error message
+            member _.lessThanLen (max : int) = 
+                let msg field = 
+                    sprintf "%s must be at least %i characters" field max
+                x.lessThanLen max msg
 
             /// Validate string is not null or "" with the default error message
-            member _.notEmpty = this.notEmpty (fun field -> sprintf "%s must not be empty" field)
+            member _.notEmpty = 
+                let msg field = sprintf "%s must not be empty" field
+                x.notEmpty msg
 
-            /// Validate string matches regular expression with the default error message
-            member _.pattern (pattern : string) = this.pattern pattern (fun field -> sprintf "%s must match pattern %s" field pattern)
-    
+            /// Validate string matches regular expression with the default 
+            /// error message
+            member _.pattern (pattern : string) = 
+                let msg field = sprintf "%s must match pattern %s" field pattern
+                x.pattern pattern msg
+
         type DefaultGuidValidator(this : GuidValidator) =
             inherit DefaultEqualityValidator<Guid>(this)
 
-            /// Validate System.Guid is null or "" with the default error message
-            member _.empty = this.empty (fun field -> sprintf "%s must be empty" field)
+            /// Validate System.Guid is null or "" with the default error 
+            /// message
+            member _.empty = 
+                let msg field = sprintf "%s must be empty" field
+                this.empty msg
 
-            /// Validate System.Guid is not null or "" with the default error message
-            member _.notEmpty = this.notEmpty (fun field -> sprintf "%s must not be empty" field)
+            /// Validate System.Guid is not null or "" with the default error 
+            /// message
+            member _.notEmpty = 
+                let msg field = sprintf "%s must not be empty" field
+                this.notEmpty msg
 
-        /// Execute validator if 'a is Some, otherwise return Failure with the default error message
-        let required (validator : Validator<'a>) (field : string) (value : 'a option) : ValidationResult<'a> =  
-            required validator (fun field -> sprintf "%s is required" field) field value
+        /// Execute validator if 'a is Some, otherwise return Failure with the 
+        /// default error message
+        let required 
+            (validator : string -> 'a -> Result<'a, ValidationErrors>) 
+            (field : string) 
+            (value : 'a option) =
+            let msg field = sprintf "%s is required" field
+            required validator msg field value
 
         /// DateTime validators with the default error messages
         let DateTime = DefaultComparisonValidator<DateTime>(DateTime)
-        
+
         /// DateTimeOffset validators with the default error messages
         let DateTimeOffset = DefaultComparisonValidator<DateTimeOffset>(DateTimeOffset)
-        
+
         /// decimal validators with the default error messages
         let Decimal = DefaultComparisonValidator<decimal>(Decimal)
-        
+
         /// float validators with the default error messages
         let Float = DefaultComparisonValidator<float>(Float)
-        
+
         /// int32 validators with the default error messages
-        let Int = DefaultComparisonValidator<int>(Int) 
-        
+        let Int = DefaultComparisonValidator<int>(Int)
+
         /// int16 validators with the default error messages
         let Int16 = DefaultComparisonValidator<int16>(Int16)
-        
+
         /// int64 validators with the default error messages
         let Int64 = DefaultComparisonValidator<int64>(Int64)
-        
+
         /// string validators with the default error messages
         let String = DefaultStringValidator(String)
-        
+
         /// System.TimeSpan validators with the default error messages
         let TimeSpan = DefaultComparisonValidator<TimeSpan>(TimeSpan)
 
@@ -389,11 +449,11 @@ module Operators =
     /// Alias for ValidationResult.apply
     let inline (<*>) f x = ValidationResult.apply f x
 
-    /// Alias for ValidationResult.map
-    let inline (<!>) f x = ValidationResult.map f x
+    /// Alias for Result.map
+    let inline (<!>) f x = Result.map f x
 
-    /// Alias for ValidationResult.bind    
-    let inline (>>=) x f = ValidationResult.bind f x
+    /// Alias for ValidationResult.bind
+    let inline (>>=) x f = Result.bind f x
 
     /// Alias for Validator.compose
     let inline (<+>) v1 v2 = Validator.compose v1 v2
@@ -405,52 +465,52 @@ module Operators =
 
 /// Computation expression for ValidationResult<_>.
 type ValidationResultBuilder() =
-    member _.Return (value) : ValidationResult<'a> = Success value
+    member _.Return (value) = Ok value
 
-    member _.ReturnFrom (result) : ValidationResult<'a> = result
+    member _.ReturnFrom (result) = result
 
-    member _.Delay(fn) : unit -> ValidationResult<'a> = fn
+    member _.Delay(fn) = fn
 
-    member _.Run(fn) : ValidationResult<'a> = fn ()
-    
-    member _.Bind (result, binder) = ValidationResult.bind binder result
+    member _.Run(fn) = fn ()
+
+    member _.Bind (result, binder) = Result.bind binder result
 
     member x.Zero () = x.Return ()
 
-    member x.TryWith (result, exceptionHandler) = 
-        try x.ReturnFrom (result)        
+    member x.TryWith (result, exceptionHandler) =
+        try x.ReturnFrom (result)
         with ex -> exceptionHandler ex
 
-    member x.TryFinally (result, fn) = 
-        try x.ReturnFrom (result)        
+    member x.TryFinally (result, fn) =
+        try x.ReturnFrom (result)
         finally fn ()
 
-    member x.Using (disposable : #IDisposable, fn) = 
-        x.TryFinally(fn disposable, fun _ -> 
-            match disposable with 
-            | null -> () 
-            | disposable -> disposable.Dispose()) 
+    member x.Using (disposable : #IDisposable, fn) =
+        x.TryFinally(fn disposable, fun _ ->
+            match disposable with
+            | null -> ()
+            | disposable -> disposable.Dispose())
 
     member x.While (guard,  fn) =
-        if not (guard()) 
-            then x.Zero () 
-        else 
+        if not (guard())
+            then x.Zero ()
+        else
             do fn () |> ignore
             x.While(guard, fn)
 
-    member x.For (items : seq<_>, fn) = 
+    member x.For (items : seq<_>, fn) =
         x.Using(items.GetEnumerator(), fun enum ->
-            x.While(enum.MoveNext, 
+            x.While(enum.MoveNext,
                 x.Delay (fun () -> fn enum.Current)))
 
-    member x.Combine (result, fn) = 
+    member x.Combine (result, fn) =
         x.Bind(result, fun () -> fn ())
 
-    member _.MergeSources (r1 : ValidationResult<'a>, r2 : ValidationResult<'b>) : ValidationResult<'a * 'b> =
+    member _.MergeSources (r1, r2) =
         ValidationResult.zip r1 r2
 
-    member _.BindReturn (result : ValidationResult<'a>, fn : 'a -> 'b) : ValidationResult<'b> =
-        ValidationResult.map fn result
+    member _.BindReturn (result, mapping) =
+        Result.map mapping result
 
 /// Validate computation expression
 let validate = ValidationResultBuilder()

--- a/src/Validus/Validus.fsproj
+++ b/src/Validus/Validus.fsproj
@@ -20,7 +20,7 @@
 
     <!-- NuGet config -->
     <PackageId>Validus</PackageId>
-    <PackageVersion>2.0.3</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <PackageTags>fsharp;functional;validation</PackageTags>
     <PackageProjectUrl>https://github.com/pimbrouwers/Validus</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Proposal to remove the built-in choice type `ValidationResult` and replace with `Result<'a, ValidationErrors>`.

There is a cascade of effects caused by this: 
- Consumers can now rely on stdlib `Result` module
    - Internal code gains this benefit as well
- Validation plugs into third-party `Result` extensions or computation expressions
- Supports better integration into result-oriented workflows