### PR TITLE
Add source to artifact for Fable support

### DIFF
--- a/src/Validus/Validus.fsproj
+++ b/src/Validus/Validus.fsproj
@@ -37,6 +37,7 @@
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="*.fsproj; *.fs; *.js;" Exclude="**\*.fs.js" PackagePath="fable/" />
     <Compile Include="Validus.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
I was trying to use the package from Fable, but got the following:

```
error FABLE: Cannot reference entity from .dll reference, Fable packages must include F# sources: Validus.ValidationErrors
error EXCEPTION: Cannot access source path of %sValidus.Operators
error FABLE: Cannot reference entity from .dll reference, Fable packages must include F# sources: Validus.ValidationErrors
error FABLE: Cannot reference entity from .dll reference, Fable packages must include F# sources: Validus.ValidationErrors
```

@zaid-ajaj kindly suggested the changes and when I tested it locally with `nuget pack -c Release` and the resulting artifact contained `fable/Validus.fs` and `fable/Validus.fsproj`.

Hopefully this is enough for Fable to work!