### PR TITLE
Fix code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module Person =
         let emailValidator =
             let emailPatternValidator =
                 let msg = sprintf "Please provide a valid %s"
-                Check.WithMessage.String.pattern "[^@]+@[^\.]+\..+" msg
+                Check.WithMessage.String.pattern @"[^@]+@[^\.]+\..+" msg
 
             ValidatorGroup(Check.String.betweenLen 8 512)
                 .And(emailPatternValidator)
@@ -169,7 +169,7 @@ open Validus
 let msg = sprintf "Please provide a valid %s"
 
 let emailPatternValidator =
-    Check.WithMessage.String.pattern "[^@]+@[^\.]+\..+" msg
+    Check.WithMessage.String.pattern @"[^@]+@[^\.]+\..+" msg
 
 // A custom validator that uses System.Net.Mail to validate email
 let mailAddressValidator =


### PR DESCRIPTION
While the code in the `readme.md` was valid, it is uncommon to rely on the fact that `"\."` is not treated as an escape and is equal to the string `"\\."`. Using the quoted string, i.e. `"@"xyz\,abc"` ensures that you wouldn't accidentally use a backslash that is a special escape.

As a bonus, it removes the redness of the code.