### PR TITLE
Add combinators operators

### DIFF
--- a/src/Validus.sln
+++ b/src/Validus.sln
@@ -1,23 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{68D6BE36-B2EF-431B-AB84-0D1CA5DC3AD0}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Validus", "Validus\Validus.fsproj", "{5A225D23-85CE-4EF8-A165-FB7BCAF50EB9}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Validus", "Validus\Validus.fsproj", "{5A225D23-85CE-4EF8-A165-FB7BCAF50EB9}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "..\test", "{0A2D3E39-FAE1-49DA-AD6D-22A4B81E4FA9}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0A2D3E39-FAE1-49DA-AD6D-22A4B81E4FA9}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Validus.Tests", "..\test\Validus.Tests\Validus.Tests.fsproj", "{5027F0E2-6B67-41F4-A13C-23BC5AA80C94}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Validus.Tests", "..\test\Validus.Tests\Validus.Tests.fsproj", "{5027F0E2-6B67-41F4-A13C-23BC5AA80C94}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5A225D23-85CE-4EF8-A165-FB7BCAF50EB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -29,8 +26,14 @@ Global
 		{5027F0E2-6B67-41F4-A13C-23BC5AA80C94}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5027F0E2-6B67-41F4-A13C-23BC5AA80C94}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5A225D23-85CE-4EF8-A165-FB7BCAF50EB9} = {68D6BE36-B2EF-431B-AB84-0D1CA5DC3AD0}
 		{5027F0E2-6B67-41F4-A13C-23BC5AA80C94} = {0A2D3E39-FAE1-49DA-AD6D-22A4B81E4FA9}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3793603E-DE82-4CD5-9A4B-D82BE1E3A8E7}
 	EndGlobalSection
 EndGlobal

--- a/src/Validus/Operators.fs
+++ b/src/Validus/Operators.fs
@@ -1,25 +1,23 @@
 namespace Validus
 
 module Operators =
-    // TODO Abel
-    let map (f: Validator<'a, 'b>) (g: 'b -> 'c): Validator<'a, 'c> =
-        fun a b -> Result.map g (f a b)
+    let map (f: Validator<'a, 'b>) (g: 'b -> 'c) : Validator<'a, 'c> = fun a b -> Result.map g (f a b)
 
-    let bind (f: Validator<'a, 'b>) g: Validator<'a, 'b> =
+    let bindResult (f: Validator<'a, 'b>) (g: 'b -> Result<'c, _>) : Validator<'a, 'c> =
         fun a b -> Result.bind g (f a b)
 
-    let compose (v1: Validator<'a, 'a>) (v2: Validator<'a, 'a>): Validator<'a, 'a> =
+    let compose (v1: Validator<'a, 'a>) (v2: Validator<'a, 'a>) : Validator<'a, 'a> =
         fun a b ->
             match v1 a b, v2 a b with
-            | Ok a, Ok _   -> Ok a
-            | Error e, Ok _   -> Error e
-            | Ok _, Error e   -> Error e
-            | Error e1, Error e2 -> Error (ValidationErrors.merge e1 e2)
+            | Ok a, Ok _ -> Ok a
+            | Error e, Ok _ -> Error e
+            | Ok _, Error e -> Error e
+            | Error e1, Error e2 -> Error(ValidationErrors.merge e1 e2)
 
-    let kleisli (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>): Validator<'a, 'c> =
+    let kleisli (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>) : Validator<'a, 'c> =
         fun x y -> Result.bind (v2 x) (v1 x y)
 
-    let pickLeft (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>): Validator<'a, 'b> =
+    let pickLeft (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>) : Validator<'a, 'b> =
         fun x y ->
             match v1 x y with
             | Ok v ->
@@ -29,7 +27,7 @@ module Operators =
             | Error e -> Error e
 
     // pickRight behaves the same as Kleisli for validators
-    let pickRight (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>): Validator<'a, 'c> =
+    let pickRight (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>) : Validator<'a, 'c> =
         fun x y ->
             match v1 x y with
             | Ok v ->
@@ -39,7 +37,7 @@ module Operators =
             | Error e -> Error e
 
     // pickRight behaves the same as Kleisli for validators
-    let pickBoth (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>): Validator<'a, 'b * 'c> =
+    let pickBoth (v1: Validator<'a, 'b>) (v2: Validator<'b, 'c>) : Validator<'a, 'b * 'c> =
         fun x y ->
             match v1 x y with
             | Ok v ->
@@ -48,10 +46,54 @@ module Operators =
                 | Error e -> Error e
             | Error e -> Error e
 
-    let (<!>) f g = map f g
-    let (>>=) f g = bind f g
-    let (<>=>) v1 v2 = compose v1 v2
+    let choice (v1: Validator<'a, 'b>) (v2: Validator<'a, 'b>) : Validator<'a, 'b> =
+        fun x y ->
+            match v1 x y with
+            | Ok v -> Ok v
+            | Error e1 ->
+                match v2 x y with
+                | Ok v -> Ok v
+                | Error e2 -> ValidationErrors.merge e1 e2 |> Error
+
+
+    /// Map the Ok result of a validator, high precence, for use with choice (<|>).
+    let ( *|* ) f g = map f g
+
+    /// Set the Ok result of a validator to a fixed value, high precedence, for use with choice (<|>).
+    let ( *| ) f x = map f (fun _ -> x)
+
+    /// Map the Ok result of a validator, low precence, for use in chained validation
+    let (>>|) f g = map f g
+
+    /// Set the Ok result of a validator to a fixed value, low precedence, for use in chained validation
+    let (>|) f x = map f (fun _ -> x)
+
+    /// Bind the Ok result of a validator with a one-argument function that returns a Result
+    let (>>=) f g = bindResult f g
+
+    /// Reverse-bind the Ok result of a validator with a one-argument function that returns a Result
+    let (<<=) f g = bindResult g f
+
+    /// Set the Ok result of a validator to a fixed Result value
+    let (>>%) f x = bindResult f (fun _ -> x)
+
+    /// Compose two validators of equal types
+    let (<+>) v1 v2 = compose v1 v2
+
+    /// Introduce choice: if the rh-side validates Ok, pick that result, otherwise, continue with the next validator
+    let (<|>) v1 v2 = choice v1 v2
+
+    /// Kleisli-bind two validators. Other than Compose (<+>), this can change the result type.
     let (>=>) v1 v2 = kleisli v1 v2
+
+    /// Reverse kleisli-bind two validators (rh-side is evaluated first). Other than Compose (<+>), this can change the result type.
+    let (<=<) v1 v2 = kleisli v2 v1
+
+    /// Compose two validators, but keep the result of the lh-side. Ignore the result of the rh-side, unless it returns an Error.
     let (.>>) v1 v2 = pickLeft v1 v2
-    let (>>.) v1 v2 = pickLeft v1 v2
+
+    /// Compose two validators, but keep the result of the rh-side. Ignore the result of the lh-side, unless it returns an Error.
+    let (>>.) v1 v2 = pickRight v1 v2
+
+    /// Compose two validators, and keep the result of both sides as a tuple.
     let (.>>.) v1 v2 = pickBoth v1 v2

--- a/test/Validus.Tests/.fantomasignore
+++ b/test/Validus.Tests/.fantomasignore
@@ -1,0 +1,1 @@
+OperatorTests.fs

--- a/test/Validus.Tests/OperatorTests.fs
+++ b/test/Validus.Tests/OperatorTests.fs
@@ -2,7 +2,212 @@ module Validus.Operators.Tests
 
 open System
 open Xunit
+open FsCheck.Xunit
 open FsUnit.Xunit
+open Swensen.Unquote
 open Validus
+open Validus.Operators
+open System.Globalization
 
-// TODO Abel
+type AgeGroup =
+    | Adult of int
+    | Child
+    | Senior
+
+module Result =
+    let isOkValue x =
+        function
+        | Ok y -> y = x
+        | Error _ -> false
+
+    let containsErrorValue x =
+        function
+        | Ok _ -> false
+        | Error e -> e |> ValidationErrors.toList |> List.contains x
+
+    let vError x y =
+        Error <| ValidationErrors.create x [y]
+
+module Int =
+    /// Minimalistic TryParse function for testing with bind
+    /// that allows decimal point in integers, but truncates the result to an int.
+    let tryParseFromDecimal lbl (x: string) =
+        let x, y = Decimal.TryParse(x, NumberStyles.Integer ||| NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture)
+        if x then Ok(int y)
+        else Error <| ValidationErrors.create lbl ["Not a number"]
+
+[<Fact>]
+let ``Test choice and reverse kleisli operator`` () =
+    let ageValidator =
+        Check.Int.between 0 17 *| Child
+        <|> Check.Int.greaterThan 65 *| Senior
+        <|> Check.Int.between 18 65 *|* fun x -> Adult x
+        <=< Check.Int.between 0 120
+        <=< Check.String.pattern @"\d+" *|* Int32.Parse
+
+
+    test <@ ageValidator "Age" "12"  |> Result.isOkValue Child @>
+    test <@ ageValidator "Age" "18"  |> Result.isOkValue (Adult 18) @>
+    test <@ ageValidator "Age" "66"  |> Result.isOkValue Senior @>
+    test <@ ageValidator "Age" "-1"  |> Result.containsErrorValue "'Age' must be between 0 and 120" @>
+    test <@ ageValidator "Age" "foo" |> Result.containsErrorValue "'Age' must match pattern \d+" @>
+    test <@ ageValidator "Age" "200" |> Result.containsErrorValue "'Age' must be between 0 and 120" @>
+
+[<Fact>]
+let ``Test choice and forward kleisli operator`` () =
+    let ageValidator =
+        Check.String.pattern @"\d+" *|* Int32.Parse
+        >=> Check.Int.between 0 120
+        >=> (Check.Int.between 0 17  *| Child
+        <|> Check.Int.greaterThan 65 *| Senior
+        <|> Check.Int.between 18 65  *|* Adult)
+
+
+    test <@ ageValidator "Age" "12"  |> Result.isOkValue Child @>
+    test <@ ageValidator "Age" "18"  |> Result.isOkValue (Adult 18) @>
+    test <@ ageValidator "Age" "66"  |> Result.isOkValue Senior @>
+    test <@ ageValidator "Age" "-1"  |> Result.containsErrorValue "'Age' must be between 0 and 120" @>
+    test <@ ageValidator "Age" "foo" |> Result.containsErrorValue "'Age' must match pattern \d+" @>
+    test <@ ageValidator "Age" "200" |> Result.containsErrorValue "'Age' must be between 0 and 120" @>
+
+[<Fact>]
+let ``Test bind operator`` () =
+    let decimalByteValidator =
+        Check.String.pattern @"[\d\.]+"
+        >>= Int.tryParseFromDecimal "Number"
+        >=> Check.Int.between 0 255
+
+    test <@ decimalByteValidator "Byte" "33" |> Result.isOkValue 33 @>
+    test <@ decimalByteValidator "Byte" "33.99" |> Result.isOkValue 33 @>
+    test <@ decimalByteValidator "Byte" "33.99." |> Result.containsErrorValue "Not a number" @>
+
+let tryRange255 lbl = function x when x < 255 -> Ok x     | _ -> Result.vError lbl "Wrong range"
+let tryFizz lbl     = function x when x % 3 = 0 -> Ok x   | _ -> Result.vError lbl "Not a Fizz"
+let tryBuzz lbl     = function x when x % 5 = 0 -> Ok x   | _ -> Result.vError lbl "Not a Buzz"
+let tryFizzBuzz lbl = function x when x % 15 = 0 -> Ok x  | _ -> Result.vError lbl "Not a FizzBuzz"
+
+[<Fact>]
+let ``Test multiple bind operators fizzbuzz`` () =
+    let fizzBuzzValidator =
+        Check.String.pattern @"[\d\.]+"
+        >>= Int.tryParseFromDecimal "Number"
+        >>= tryRange255 "Byte"
+        >>= tryFizz "Fizz"
+        >>= tryBuzz "Buzz"
+
+    test <@ fizzBuzzValidator "FizzBuzz" "0"     |> Result.isOkValue 0 @>
+    test <@ fizzBuzzValidator "FizzBuzz" "165"   |> Result.isOkValue 165 @>
+    test <@ fizzBuzzValidator "FizzBuzz" "30.99" |> Result.isOkValue 30 @>
+    test <@ fizzBuzzValidator "FizzBuzz" "256"   |> Result.containsErrorValue "Wrong range" @>
+    test <@ fizzBuzzValidator "FizzBuzz" "9"     |> Result.containsErrorValue "Not a Buzz" @>
+    test <@ fizzBuzzValidator "FizzBuzz" "20"    |> Result.containsErrorValue "Not a Fizz" @>
+
+type FizzBuzz = Fizz of int | Buzz of int | FizzBuzz of int
+
+[<Fact>]
+let ``Test multiple bind and pickLeft & Right operators fizzbuzz`` () =
+    // only ever returns Buzz or error.
+    let fizzBuzzValidator =
+        Check.String.pattern @"[\d\.]+"
+        >>= Int.tryParseFromDecimal "Number"
+        >>= tryRange255 "Byte"
+        .>> tryFizz *|* Fizz  // a log statement or other side effect makes more sense here, as we ignore the resutl
+        >>. tryBuzz *|* Buzz
+
+    test <@ fizzBuzzValidator "Byte" "0" |> Result.isOkValue (Buzz 0) @>
+    test <@ fizzBuzzValidator "Byte" "3" |> Result.containsErrorValue "Not a Buzz" @>
+    test <@ fizzBuzzValidator "Byte" "15" |> Result.isOkValue (Buzz 15) @>
+
+[<Fact>]
+let ``Test combination of bind, kleisli and choice operators fizzbuzz`` () =
+    let fizzBuzzValidator =
+        Check.String.pattern @"[\d\.]+"
+        >>= Int.tryParseFromDecimal "Number"
+        >>= tryRange255 "Byte"
+        >=> (tryFizzBuzz *|* FizzBuzz
+        <|> tryFizz      *|* Fizz  // a log statement or other side effect makes more sense here, as we ignore the resutl
+        <|> tryBuzz      *|* Buzz)
+
+    test <@ fizzBuzzValidator "FizzBuzz" "0"   |> Result.isOkValue (FizzBuzz 0) @>
+    test <@ fizzBuzzValidator "FizzBuzz" "150" |> Result.isOkValue (FizzBuzz 150) @>
+    test <@ fizzBuzzValidator "FizzBuzz" "21"  |> Result.isOkValue (Fizz 21) @>
+    test <@ fizzBuzzValidator "FizzBuzz" "50"  |> Result.isOkValue (Buzz 50) @>
+    test <@ fizzBuzzValidator "FizzBuzz" "254" |> Result.containsErrorValue "Not a Buzz" @>
+    test <@ fizzBuzzValidator "FizzBuzz" "254" |> Result.containsErrorValue "Not a Fizz" @>
+    test <@ fizzBuzzValidator "FizzBuzz" "254" |> Result.containsErrorValue "Not a FizzBuzz" @>
+    test <@ fizzBuzzValidator "FizzBuzz" "500" |> Result.containsErrorValue "Wrong range" @>
+    test <@ fizzBuzzValidator "FizzBuzz" "Foo" |> Result.containsErrorValue "'FizzBuzz' must match pattern [\d\.]+" @>
+
+[<Fact>]
+let ``Use pickleft to parse as decimal, do some logging, but keep the input string`` () =
+    let mutable x = 0
+    let log _ _ = x <- x + 1; Ok()   // fake logger for testing
+    let percentageValidator =
+        Check.String.pattern @"[\d\.]+"
+        .>> log
+        .>> (Int.tryParseFromDecimal >=> Check.Int.between 0 100)
+        .>> log
+        >>= (sprintf "%s%%" >> Ok)
+
+    test <@ percentageValidator "Percentage" "10" |> Result.isOkValue "10%" @>
+    test <@ ignore <| percentageValidator "Percentage" "100"; x = 2 @>  // 'test' creates new closure
+    test <@ percentageValidator "Percentage" "10.10.10" |> Result.containsErrorValue "Not a number" @>
+
+[<Fact>]
+let ``Use pickBoth and pickLeft in combination, sad path`` () =
+    let mutable x = 0
+    let log _ _ = Ok() // fake logger
+    let storeDbFail _ _ = Result.vError "Db" "Connection lost"   // fake side effect with result
+    let parseAndStore =
+        Check.String.pattern @"[\d\.]+"
+        .>> Int.tryParseFromDecimal
+        .>>. storeDbFail
+        >| 42 // we'll never get here
+        .>> log
+
+    test <@ parseAndStore "Data" "10" |> Result.containsErrorValue "Connection lost" @>
+    test <@ parseAndStore "Data" "3.3.3" |> Result.containsErrorValue "Not a number" @>
+
+[<Fact>]
+let ``Use pickBoth and pickLeft in combination, happy path`` () =
+    let mutable x = 0
+    let log _ _ = Ok() // fake logger
+    let callService _ _ = Ok "HTTP: 200 Ok"   // fake side effect with result
+    let parseAndStore =
+        Check.String.pattern @"[\d\.]+"
+        .>> Int.tryParseFromDecimal
+        .>>. callService
+        .>> log
+        >>| fun (x, dbresult) -> $"Result: {dbresult}, data: {x}"
+
+    test <@ parseAndStore "Data" "10" |> Result.isOkValue "Result: HTTP: 200 Ok, data: 10" @>
+    test <@ parseAndStore "Data" "3.3.3" |> Result.containsErrorValue "Not a number" @>
+
+[<Fact>]
+let ``Show composability of all low precedence operators`` () =
+    let mutable x = 0
+    let log _ _ = x <- x + 1; Ok() // fake logger
+    let callService _ _ = Ok "HTTP: 200 Ok"   // fake side effect with result
+
+    // The following doesn't make sense, but is here to ensure composibility with operators
+    // and to prevent that, in the event of updates, those operators stop working together
+    let someSillyCombination =
+        fun y -> if true then Ok y else Result.vError "Oops" "Oops"
+        <<= Check.Int.lessThan 100
+        >>| string
+        >=> Check.String.pattern @"[\d\.]+"
+        .>> Int.tryParseFromDecimal
+        .>>. callService
+        >>| fun (a, b) -> a, Adult 99
+        >>| (snd >> string)
+        >=> Check.String.betweenLen 0 10
+        >| 42
+        >>. log
+        >| Guid.Empty
+        >>= fun y -> if y = Guid.Empty then Ok 42 else Result.vError "Oops" "Very oops"
+        >=> ((fun y -> Ok (Random().Next(0, 10))) <<= Check.Int.lessThan 100)
+        >=> Check.Int.lessThan 11
+
+    test <@ someSillyCombination "Data" 200 |> Result.containsErrorValue "'Data' must be less than 100" @>
+    test <@ someSillyCombination "Data" 90 |> function Ok x when x < 11 -> true | _ -> false @>
+    test <@ ignore <| someSillyCombination "Data" 10; x = 1 @>

--- a/test/Validus.Tests/Validus.Tests.fsproj
+++ b/test/Validus.Tests/Validus.Tests.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include=".fantomasignore" />
     <Compile Include="ValidationErrorsTests.fs" />
     <Compile Include="ValidatorTests.fs" />
     <Compile Include="GuidValidatorTests.fs" />
@@ -23,6 +24,7 @@
     <PackageReference Include="FsCheck.Xunit" Version="2.14.*" />
     <PackageReference Include="FsUnit.xUnit" Version="4.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
+    <PackageReference Include="Unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
As discussed in #11. This is the follow-up. Sorry it took a bit longer, but I needed some time with Validus to get a better feel for it. Either way, here it is, including a bunch of tests. I used Unquote for the tests as otherwise this would take too much time, but feel free to split them up in more smaller tests with FsCheck if you'd like.

The original code that you added contained some errors (my fault, I didn't correct my own code in the other thread). But those are fixed now. The following operators are now defined (feel free to criticize / change them, but keep in mind that any new choice should rely on a proper precedence order):

```f#
/// Map the Ok result of a validator, high precence, for use with choice (<|>).
let ( *|* ) f g = map f g

/// Set the Ok result of a validator to a fixed value, high precedence, for use with choice (<|>).
let ( *| ) f x = map f (fun _ -> x)

/// Map the Ok result of a validator, low precence, for use in chained validation
let (>>|) f g = map f g

/// Set the Ok result of a validator to a fixed value, low precedence, for use in chained validation
let (>|) f x = map f (fun _ -> x)

/// Bind the Ok result of a validator with a one-argument function that returns a Result
let (>>=) f g = bindResult f g

/// Reverse-bind the Ok result of a validator with a one-argument function that returns a Result
let (<<=) f g = bindResult g f

/// Set the Ok result of a validator to a fixed Result value
let (>>%) f x = bindResult f (fun _ -> x)

/// Compose two validators of equal types
let (<+>) v1 v2 = compose v1 v2

/// Introduce choice: if the rh-side validates Ok, pick that result, otherwise, report error and continue with the next validator, if any.
let (<|>) v1 v2 = choice v1 v2

/// Kleisli-bind two validators. Other than Compose (<+>), this can change the result type.
let (>=>) v1 v2 = kleisli v1 v2

/// Reverse kleisli-bind two validators (rh-side is evaluated first). Other than Compose (<+>), this can change the result type.
let (<=<) v1 v2 = kleisli v2 v1

/// Compose two validators, but keep the result of the lh-side. Ignore the result of the rh-side, unless it returns an Error.
let (.>>) v1 v2 = pickLeft v1 v2

/// Compose two validators, but keep the result of the rh-side. Ignore the result of the lh-side, unless it returns an Error.
let (>>.) v1 v2 = pickRight v1 v2

/// Compose two validators, and keep the result of both sides as a tuple.
let (.>>.) v1 v2 = pickBoth v1 v2

```